### PR TITLE
Add external event logging and opened status indicator

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -27,6 +27,45 @@ img {
   border-radius: 4px;
 }
 
+.big-brother {
+  border-radius: 4px;
+  height: 70px;
+  max-width: 150px;
+  min-width: 100px;
+  display: block;
+  float: none;
+  text-align: center;
+  line-height: 60px;
+  font-size: 1.5em;
+  color: #999;
+  padding-left: 5px;
+  padding-right: 5px;
+  margin-top: 15px;
+  margin-bottom: -15px;
+  margin-left: 110px;
+  background-color: #222;
+}
+
+.big-brother span {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: normal;
+}
+
+.hsopen-unknown {
+  box-shadow: 0px 0px 6px 3px grey;
+}
+
+.hsopen-opened {
+  box-shadow: 0px 0px 6px 3px lightgreen;
+  color: lightgreen;
+}
+
+.hsopen-closed {
+  box-shadow: 0px 0px 6px 3px red;
+  color: red;
+}
+
 /* Base callout styles (regardless of theme) */
 .bs-callout {
   margin: 20px 0;

--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,19 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  before_action :check_if_hs_open
+
+  def check_if_hs_open
+    @event = LogEvent.where(event_type: "light").where("timestamp >= ?", DateTime.now.ago(1800)).order("timestamp DESC").first
+    if @event.nil?
+      @hs_open_status = "unknown"
+    else
+      if @event.value == "on"
+        @hs_open_status = "opened"
+      else
+        @hs_open_status = "closed"
+      end
+    end
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,7 @@
 
 class EventsController < ApplicationController
   before_action :set_log_event, only: [:update, :destroy, :show]
+  before_action :authenticate_user!, only: [:create]
   skip_before_filter :verify_authenticity_token, :if => Proc.new { |c|
     c.request.format == 'application/json'
   }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,48 @@
+#encoding: utf-8
+
+class EventsController < ApplicationController
+  before_action :set_log_event, only: [:update, :destroy, :show]
+  skip_before_filter :verify_authenticity_token, :if => Proc.new { |c|
+    c.request.format == 'application/json'
+  }
+
+  def index
+    @log_events = LogEvent.order('timestamp DESC').all
+    respond_to do |format|
+      format.html
+      format.json { render json: @log_events }
+    end
+  end
+
+  def create
+    @log_event = LogEvent.new
+    @log_event.assign_attributes(event_params)
+    @log_event.timestamp = Time.now if @log_event.timestamp.blank?
+
+    respond_to do |format|
+      if @log_event.save
+        format.json { render json: @log_event, status: :created }
+      else
+        format.json { render json: @log_event.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def show
+    respond_to do |format|
+      format.json { render json: @log_event }
+    end
+  end
+ 
+  private
+
+  def set_log_event
+    @log_event = LogEvent.find(params[:id])
+  end
+
+  def event_params
+    permitted_attrs = [:event_type, :value, :timestamp]
+    params.require(:event).permit(permitted_attrs)
+  end
+
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,9 +3,7 @@
 class EventsController < ApplicationController
   before_action :set_log_event, only: [:update, :destroy, :show]
   before_action :authenticate_user!, only: [:create]
-  skip_before_filter :verify_authenticity_token, :if => Proc.new { |c|
-    c.request.format == 'application/json'
-  }
+  skip_before_filter :verify_authenticity_token
 
   def index
     @log_events = LogEvent.order('timestamp DESC').all

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/models/log_event.rb
+++ b/app/models/log_event.rb
@@ -1,0 +1,15 @@
+class LogEvent < ActiveRecord::Base
+  validates :timestamp, presence: true
+  validate  :timestamp_is_in_the_past
+  validates :event_type, inclusion: { in: %w(light) }
+  validates :value, presence: true
+
+
+  private
+
+  def timestamp_is_in_the_past
+    if timestamp.present? and timestamp > Time.now
+      errors.add(:timestamp, "should be in the past")
+    end
+  end
+end

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,0 +1,20 @@
+%h1
+  = t ".title"
+
+%table.table
+  %tr
+    %th
+      = t ".time"
+    %th
+      = t ".type"
+    %th
+      = t ".value"
+  - @log_events.each do |event|
+    %tr
+      %td
+        = event.timestamp
+      %td
+        = event.event_type
+      %td
+        = event.value
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,6 +17,9 @@
             %span.icon-bar
           %a.navbar-brand#brand{href: root_path}
             =image_tag 'default.png', height: '70px'
+          .big-brother{:class => "hsopen-#{@hs_open_status}"}
+            %span
+              = t "hsopen.#{@hs_open_status}"
         .collapse.navbar-collapse#navbar
           %ul.nav.navbar-nav.lead
             %li
@@ -29,13 +32,13 @@
               %a{href: 'https://www.facebook.com/hs.minsk/photos_stream?tab=photos_albums', target: '_blank'} Фотографии
             %li
               =link_to 'Контакты', contacts_path
+
           %ul.nav.navbar-nav.navbar-right.lead
             %li
               -if user_signed_in?
                 = link_to 'Выход', destroy_user_session_path, method: :delete
               -else
                 %a{href: new_user_session_path} Вход
-
     .container
       -if notice.present?
         %br

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -59,7 +59,7 @@ Devise.setup do |config|
   # given strategies, for example, `config.http_authenticatable = [:database]` will
   # enable it only for database authentication. The supported strategies are:
   # :database      = Support basic authentication with authentication key + password
-  # config.http_authenticatable = false
+  config.http_authenticatable = true
 
   # If http headers should be returned for AJAX requests. True by default.
   # config.http_authenticatable_on_xhr = true

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -3,6 +3,10 @@ ru:
     attributes:
       project:
         public: "Публичный"
+  hsopen:
+    unknown: "УПС..."
+    opened: "ОТКРЫТО"
+    closed: "ЗАКРЫТО"
   index:
     hello_world: "Hello World!"
     what_is_it_content: "Хакерспейс (hackerspace) &mdash; мастерская-клуб, где энтузиасты могут заниматься любимым делом, \

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,13 @@
 Rails.application.routes.draw do
+
   devise_for :users
 
   resources :projects
   get '/rules', to: 'main#rules'
   get '/calendar', to: 'main#calendar'
   get '/contacts', to: 'main#contacts'
+
+  resources :events, only: [:index, :show, :create]
 
   mount Tail::Engine, at: '/tail'
   # The priority is based upon order of creation: first created -> highest priority.

--- a/db/migrate/20150103222450_create_log_events.rb
+++ b/db/migrate/20150103222450_create_log_events.rb
@@ -1,0 +1,11 @@
+class CreateLogEvents < ActiveRecord::Migration
+  def change
+    create_table :log_events do |t|
+      t.string :event_type, null_allowed: false
+      t.string :value, null_allowed: false
+      t.datetime :timestamp
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141128114427) do
+ActiveRecord::Schema.define(version: 20150103222450) do
+
+  create_table "log_events", force: true do |t|
+    t.string   "event_type"
+    t.string   "value"
+    t.datetime "timestamp"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "projects", force: true do |t|
     t.string   "name"

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class EventsControllerTest < ActionController::TestCase
+  test "should get index" do
+    get :index
+    assert_response :success
+  end
+
+  test "should get create" do
+    get :create
+    assert_response :success
+  end
+
+  test "should get show" do
+    get :show
+    assert_response :success
+  end
+
+  test "should get update" do
+    get :update
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get :destroy
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/log_events.yml
+++ b/test/fixtures/log_events.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  type: 
+  value: MyString
+  timestamp: 2015-01-04 01:24:50
+
+two:
+  type: 
+  value: MyString
+  timestamp: 2015-01-04 01:24:50

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class EventsHelperTest < ActionView::TestCase
+end

--- a/test/models/log_event_test.rb
+++ b/test/models/log_event_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LogEventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Add event logging. Every event has type, value and timestamp. Type and
value are mandatory, timestamp is optional (will be set to current
time). Log records cannot be changed.

Supported type now is "light" with values "on" and "off".

Hackerspace opened status indicator shows if anybody is in HS based on
last recorded light status log event. If its timestamp older than half
an hour before, opened status is "Unknown"

Example of command for log event:

$ curl -X POST --data "event[event_type]=light&event[value]=off" \
  http://localhost:3000/events

Signed-off-by: Yauhen Kharuzhy <jekhor@gmail.com>